### PR TITLE
Allow user to choose between using access tokens and codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,16 @@ It is recommended to add these permission to `config.xml` of your Cordova projec
 
 ### Login
 
-`AccountKitPlugin.loginWithEmail(Function success, Function failure)`
-`AccountKitPlugin.loginWithPhoneNumber(Function success, Function failure)`
+`AccountKitPlugin.loginWithEmail(Function success, Function failure, Object options)`
+`AccountKitPlugin.loginWithPhoneNumber(Function success, Function failure, Object options)`
+
+Options object: 
+
+	{
+		// Enable to use client access tokens, disable to receive code
+	  useClientAccessToken: Boolean 
+	}
+
 
 Success function returns an Object like:
 

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -37,11 +37,17 @@ public class AccountKitPlugin extends CordovaPlugin {
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     final JSONObject options = args.getJSONObject(0);
+    try {
+      Boolean useClientAccessToken =  options.getBoolean("useClientAccessToken")  
+    } catch (JSONException e) {
+      // handle error here
+    }
+    
     if ("loginWithPhoneNumber".equals(action)) {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.PHONE, callbackContext, options.getBoolean("useClientAccessToken"));
+          executeLogin(LoginType.PHONE, callbackContext, useClientAccessToken);
         }
       });
       return true;
@@ -50,7 +56,7 @@ public class AccountKitPlugin extends CordovaPlugin {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.EMAIL, callbackContext, options.getBoolean("useClientAccessToken"));
+          executeLogin(LoginType.EMAIL, callbackContext, useClientAccessToken);
         }
       });
       return true;

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -38,7 +38,7 @@ public class AccountKitPlugin extends CordovaPlugin {
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     final JSONObject options = args.getJSONObject(0);
     try {
-      Boolean useClientAccessToken =  options.getBoolean("useClientAccessToken")  
+      Boolean useClientAccessToken =  options.getBoolean("useClientAccessToken");
     } catch (JSONException e) {
       // handle error here
     }

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -36,11 +36,12 @@ public class AccountKitPlugin extends CordovaPlugin {
 
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    JSONObject options = args.getJSONObject(0);
     if ("loginWithPhoneNumber".equals(action)) {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.PHONE, callbackContext);
+          executeLogin(LoginType.PHONE, callbackContext, options.getBoolean('useClientAccessToken'));
         }
       });
       return true;
@@ -49,7 +50,7 @@ public class AccountKitPlugin extends CordovaPlugin {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.EMAIL, callbackContext);
+          executeLogin(LoginType.EMAIL, callbackContext, options.getBoolean('useClientAccessToken'));
         }
       });
       return true;
@@ -71,7 +72,7 @@ public class AccountKitPlugin extends CordovaPlugin {
     return false;
   }
 
-  public final void executeLogin(LoginType type, CallbackContext callbackContext) {
+  public final void executeLogin(LoginType type, CallbackContext callbackContext, Boolean useClientAccessToken) {
     // Set a pending callback to cordova
     loginContext = callbackContext;
     PluginResult pr = new PluginResult(PluginResult.Status.NO_RESULT);
@@ -88,10 +89,10 @@ public class AccountKitPlugin extends CordovaPlugin {
     }
 
     AccountKitActivity.ResponseType responseType = null;
-    if (true) {
-      responseType = AccountKitActivity.ResponseType.CODE;
-    } else {
+    if (useClientAccessToken) {
       responseType = AccountKitActivity.ResponseType.TOKEN;
+    } else {
+      responseType = AccountKitActivity.ResponseType.CODE;
     }
 
     Intent intent = new Intent(this.cordova.getActivity(), AccountKitActivity.class);

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -41,7 +41,7 @@ public class AccountKitPlugin extends CordovaPlugin {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.PHONE, callbackContext, options.getBoolean('useClientAccessToken'));
+          executeLogin(LoginType.PHONE, callbackContext, options.getBoolean("useClientAccessToken"));
         }
       });
       return true;
@@ -50,7 +50,7 @@ public class AccountKitPlugin extends CordovaPlugin {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          executeLogin(LoginType.EMAIL, callbackContext, options.getBoolean('useClientAccessToken'));
+          executeLogin(LoginType.EMAIL, callbackContext, options.getBoolean("useClientAccessToken"));
         }
       });
       return true;

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -26,7 +26,7 @@ public class AccountKitPlugin extends CordovaPlugin {
   private static final String TAG = "AccountKitPlugin";
   public static int APP_REQUEST_CODE = 42;
   private CallbackContext loginContext = null;
-  private Boolean useClientAccessToken = null
+  private Boolean useClientAccessToken = null;
 
   @Override
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -36,7 +36,7 @@ public class AccountKitPlugin extends CordovaPlugin {
 
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-    JSONObject options = args.getJSONObject(0);
+    final JSONObject options = args.getJSONObject(0);
     if ("loginWithPhoneNumber".equals(action)) {
       cordova.getActivity().runOnUiThread(new Runnable() {
         @Override

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -37,8 +37,9 @@ public class AccountKitPlugin extends CordovaPlugin {
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     final JSONObject options = args.getJSONObject(0);
+    Boolean useClientAccessToken = null;
     try {
-      Boolean useClientAccessToken =  options.getBoolean("useClientAccessToken");
+      useClientAccessToken = options.getBoolean("useClientAccessToken");
     } catch (JSONException e) {
       // handle error here
     }

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -87,11 +87,18 @@ public class AccountKitPlugin extends CordovaPlugin {
       e.printStackTrace();
     }
 
+    AccountKitActivity.ResponseType responseType = null;
+    if (true) {
+      responseType = AccountKitActivity.ResponseType.CODE;
+    } else {
+      responseType = AccountKitActivity.ResponseType.TOKEN;
+    }
+
     Intent intent = new Intent(this.cordova.getActivity(), AccountKitActivity.class);
     AccountKitConfiguration.AccountKitConfigurationBuilder configurationBuilder =
       new AccountKitConfiguration.AccountKitConfigurationBuilder(
         type,
-        AccountKitActivity.ResponseType.CODE);
+        responseType);
     intent.putExtra(AccountKitActivity.ACCOUNT_KIT_ACTIVITY_CONFIGURATION, configurationBuilder.build());
 
     cordova.setActivityResultCallback(this);

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -26,6 +26,7 @@ public class AccountKitPlugin extends CordovaPlugin {
   private static final String TAG = "AccountKitPlugin";
   public static int APP_REQUEST_CODE = 42;
   private CallbackContext loginContext = null;
+  private Boolean useClientAccessToken = null
 
   @Override
   public void initialize(CordovaInterface cordova, CordovaWebView webView) {
@@ -37,7 +38,6 @@ public class AccountKitPlugin extends CordovaPlugin {
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     final JSONObject options = args.getJSONObject(0);
-    final Boolean useClientAccessToken = null;
     try {
       useClientAccessToken = options.getBoolean("useClientAccessToken");
     } catch (JSONException e) {

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -91,7 +91,7 @@ public class AccountKitPlugin extends CordovaPlugin {
     AccountKitConfiguration.AccountKitConfigurationBuilder configurationBuilder =
       new AccountKitConfiguration.AccountKitConfigurationBuilder(
         type,
-        AccountKitActivity.ResponseType.TOKEN);
+        AccountKitActivity.ResponseType.CODE);
     intent.putExtra(AccountKitActivity.ACCOUNT_KIT_ACTIVITY_CONFIGURATION, configurationBuilder.build());
 
     cordova.setActivityResultCallback(this);

--- a/src/android/AccountKitPlugin.java
+++ b/src/android/AccountKitPlugin.java
@@ -37,7 +37,7 @@ public class AccountKitPlugin extends CordovaPlugin {
   @Override
   public boolean execute(String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     final JSONObject options = args.getJSONObject(0);
-    Boolean useClientAccessToken = null;
+    final Boolean useClientAccessToken = null;
     try {
       useClientAccessToken = options.getBoolean("useClientAccessToken");
     } catch (JSONException e) {

--- a/src/ios/AKPlugin.m
+++ b/src/ios/AKPlugin.m
@@ -9,7 +9,7 @@
 
 - (void)pluginInitialize {
   if (_accountKit == nil) {
-    _accountKit = [[AKFAccountKit alloc] initWithResponseType:AKFResponseTypeAccessToken];
+    _accountKit = [[AKFAccountKit alloc] initWithResponseType:AKFResponseTypeAuthorizationCode];
     _theme = [AKFTheme defaultTheme];
   }
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/www/plugin.js
+++ b/www/plugin.js
@@ -3,11 +3,11 @@ var exec = require('cordova/exec');
 var PLUGIN_NAME = 'AccountKitPlugin';
 
 var AccountKitPlugin = {
-  loginWithPhoneNumber: function(s, f) {
-    exec(s, f, PLUGIN_NAME, 'loginWithPhoneNumber', []);
+  loginWithPhoneNumber: function(s, f, o) {
+    exec(s, f, PLUGIN_NAME, 'loginWithPhoneNumber', [o]);
   },
-  loginWithEmail: function(s, f) {
-    exec(s, f, PLUGIN_NAME, 'loginWithEmail', []);
+  loginWithEmail: function(s, f, o) {
+    exec(s, f, PLUGIN_NAME, 'loginWithEmail', [o]);
   },
   getAccessToken: function(s, f) {
     exec(s, f, PLUGIN_NAME, 'getAccessToken', []);


### PR DESCRIPTION
My attempt at solving #9 

Definitely still needs some work and error handling. Any help would be much appreciated.

Might want to set options default from JS side, currently there are no defaults and will crash if the options object is not passed with a `useClientAccessToken` value.

I've also not touched the iOS side.