### PR TITLE
Identical function signature with other platforms

### DIFF
--- a/src/ios/AKPlugin.m
+++ b/src/ios/AKPlugin.m
@@ -26,11 +26,9 @@
   NSString *defaultCountryCode = [options objectForKey:@"defaultCountryCode"];
   BOOL facebookNotificationsEnabled = [[options objectForKey:@"facebookNotificationsEnabled"] boolValue];
   NSArray *initialPhoneNumber = [options objectForKey:@"initialPhoneNumber"];
-  if ([initialPhoneNumber count] == 2) {
-    preFillPhoneNumber = [[AKFPhoneNumber alloc]initWithCountryCode:[initialPhoneNumber objectAtIndex:0]
-                                                        phoneNumber:[initialPhoneNumber objectAtIndex:1]];
-  }
-
+  preFillPhoneNumber = [[AKFPhoneNumber alloc]initWithCountryCode:defaultCountryCode
+                                                      phoneNumber:initialPhoneNumber];
+  
   _responseType = useAccessToken ? AKFResponseTypeAccessToken: AKFResponseTypeAuthorizationCode;
   _accountKit = [[AKFAccountKit alloc] initWithResponseType:_responseType];
 


### PR DESCRIPTION
This code requires iOS code to pass array (["+6", "111111"]) in initialPhoneNumber options. This differs with Android and Browser platform, whereby initialPhoneNumber is simply a string. Besides, the country code is available in defaultCountryCode options.